### PR TITLE
Commented out unncecessary current user timezone determination

### DIFF
--- a/slack-timezone-converter.rb
+++ b/slack-timezone-converter.rb
@@ -56,7 +56,7 @@ end
 
 timezones = timezones.sort_by{ |key, value| value }
 
-Time.zone = users[CURRENT_USER][:tz]
+#Time.zone = users[CURRENT_USER][:tz]
 
 # Connect to Slack
 


### PR DESCRIPTION
Commented out unncecessary current user timezone determination, for Slack using tokens it would be the bot which will always fail due to having no timezone set. The current code fails on that line if I run locally.
