### PR TITLE
Deal with fractional offsets. 

### DIFF
--- a/slack-timezone-converter.rb
+++ b/slack-timezone-converter.rb
@@ -44,7 +44,6 @@ JSON.parse(response.body)['members'].each do |user|
   offset, label = user['tz_offset'], user['tz']
   next if offset.nil? or offset == 0 or label.nil? or user['deleted']
   label = ActiveSupport::TimeZone.find_tzinfo(label).current_period.abbreviation.to_s
-  offset /= 3600
   if key = timezones.key(offset) and !key.split(' / ').include?(label)
     timezones.delete(key)
     label = key + ' / ' + label
@@ -81,7 +80,7 @@ client.on :message do |data|
       i = 0
       timezones.each do |label, offset|
         i += 1
-        localtime = time + offset.to_i.hours
+        localtime = time + offset
         emoji = slack_clock_emoji_from_time(localtime)
         message = "#{emoji} #{localtime.strftime('%H:%M')} #{label}"
         message += (i % PER_LINE.to_i == 0) ? "\n" : " "


### PR DESCRIPTION
@caiosba this is probably wrong since I haven't run it fully and don't actually know ruby, but I'm trying to fix a small bug with offsets that are not full hour differences. E.g., India is 5.5 hours ahead of the UK. In the master branch, the code adds only 5 hours because 
```
localtime = time + offset.to_i.hours
```
truncates offset to an integer. From what I can see in the code, it seems like Slack gives an offset in seconds, and my quick check with `irb` suggests we can just add that offset directly to a time object in ruby. 

```
$ irb
irb(main):001:0> require 'time'
=> true
irb(main):002:0> time=Time.parse("16:00 BST").utc
=> 2021-04-26 15:00:00 UTC
irb(main):003:0> time+=(5.5*3600)
=> 2021-04-26 20:30:00 UTC
```

So that's what I'm trying to do here :-) 